### PR TITLE
[TASK] Make GroupedResultParser compatible with EXT:solr 9

### DIFF
--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/Parser/GroupedResultsParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/Parser/GroupedResultsParserTest.php
@@ -49,7 +49,8 @@ class GroupedResultsParserTest extends UnitTest
         $resultSet = $this->getSearchResultSetMockFromConfigurationAndFixtureFileName($configurationMock, 'fake_solr_response_group_on_queries.json');
 
         $parser = new GroupedResultParser();
-        $searchResultsCollection = $parser->parse($resultSet);
+        $searchResultsSet = $parser->parse($resultSet);
+        $searchResultsCollection = $searchResultsSet->getSearchResults();
 
         $this->assertTrue($searchResultsCollection->getHasGroups());
         $this->assertSame(1, $searchResultsCollection->getGroups()->getCount());
@@ -75,7 +76,9 @@ class GroupedResultsParserTest extends UnitTest
         $resultSet = $this->getSearchResultSetMockFromConfigurationAndFixtureFileName($configurationMock, 'fake_solr_response_group_on_type_field.json');
 
         $parser = new GroupedResultParser();
-        $searchResultsCollection = $parser->parse($resultSet);
+        $searchResultsSet = $parser->parse($resultSet);
+        $searchResultsCollection = $searchResultsSet->getSearchResults();
+
 
         $this->assertTrue($searchResultsCollection->getHasGroups());
         $this->assertSame(1, $searchResultsCollection->getGroups()->getCount(), 'There should be 1 Groups of search results');

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -85,6 +85,7 @@ class SearchResultSetServiceTest extends UnitTest
         $fakeRequest = $this->getDumbMock(SearchRequest::class);
         $fakeRequest->expects($this->any())->method('getResultsPerPage')->willReturn(10);
         $fakeRequest->expects($this->any())->method('getContextTypoScriptConfiguration')->will($this->returnValue($typoScriptConfiguration));
+        $fakeRequest->expects($this->any())->method('getAdditionalFilters')->willReturn([]);
         $searchResultSet = $searchResultSetService->search($fakeRequest);
 
         $this->assertSame(1, $searchResultSet->getSearchResults()->getGroups()->getCount(), 'There should be 1 Groups of search results');


### PR DESCRIPTION
This pr:

* Adapts the GroupedResultParser to return the SearchResultSet
* Parse the maximum score and set it on the SearchResultSet

Fixes: #6