### PR TITLE
[TASK] Use SearchResultSet::getAllResultCount instead of Search::getNumberOfResults

### DIFF
--- a/Classes/Domain/Search/ResultSet/Grouping/Parser/GroupedResultParser.php
+++ b/Classes/Domain/Search/ResultSet/Grouping/Parser/GroupedResultParser.php
@@ -61,10 +61,10 @@ class GroupedResultParser extends AbstractResultParser {
         }
 
         $searchResultCollection = $this->parseGroups($resultSet, $groupsConfiguration, $searchResultCollection);
-
-        $this->calculateOverallMaximumScore($resultSet, $searchResultCollection);
-
         $resultSet->setSearchResults($searchResultCollection);
+
+        $this->calculateSummarizedGroupData($resultSet);
+
         return $resultSet;
     }
 
@@ -300,15 +300,16 @@ class GroupedResultParser extends AbstractResultParser {
     }
 
     /**
-     * Calculates the overall maximum score and passed it to the SearchResultSet.
+     * Some data (maximumScore and allResultCount is summarized from all groups and assigned
+     * to the SearchResultSet to have that data available independent from the groups.
      *
      * @param SearchResultSet $resultSet
-     * @param $searchResultCollection
      */
-    private function calculateOverallMaximumScore(SearchResultSet $resultSet, $searchResultCollection)
+    private function calculateSummarizedGroupData(SearchResultSet $resultSet)
     {
         $overAllMaximumScore = 0.0;
-        foreach ($searchResultCollection->getGroups() as $group) {
+        $allResultCount = 0;
+        foreach ($resultSet->getSearchResults()->getGroups() as $group) {
             /** @var $group Group */
             foreach ($group->getGroupItems() as $groupItem) {
                 /** @var $groupItem GroupItem */
@@ -316,9 +317,13 @@ class GroupedResultParser extends AbstractResultParser {
                     $overAllMaximumScore = $groupItem->getMaximumScore();
                 }
 
+                $allResultCount += $groupItem->getAllResultCount();
+
             }
         }
 
         $resultSet->setMaximumScore($overAllMaximumScore);
+        $resultSet->setAllResultCount($allResultCount);
     }
+
 }

--- a/Resources/Private/Templates/Search/Results.html
+++ b/Resources/Private/Templates/Search/Results.html
@@ -62,25 +62,17 @@
 					</f:then>
 				</f:if>
 
-				<f:if condition="{resultSet.usedSearch.numberOfResults}">
+				<f:if condition="{resultSet.allResultCount}">
 					<span class="result-found">
-						<f:if condition="{resultSet.usedSearch.numberOfResults} == 1">
+						<f:if condition="{resultSet.allResultCount} == 1">
 							<f:then>
 								<s:translate key="results_found.singular" arguments="{0:resultSet.usedSearch.queryTime}">Found 1 result in %d seconds</s:translate>
 							</f:then>
 							<f:else>
-								<s:translate key="results_found" arguments="{0:resultSet.usedSearch.numberOfResults, 1: resultSet.usedSearch.queryTime}">Found %d results in %d seconds</s:translate>
+								<s:translate key="results_found" arguments="{0:resultSet.allResultCount, 1: resultSet.usedSearch.queryTime}">Found %d results in %d seconds</s:translate>
 							</f:else>
 						</f:if>
 					</span>
-					<span class="result-range">
-						<s:pageBrowserRange>
-							<s:translate key="results_range" arguments="{0:from, 1: to, 2: total}">Results %d until %d of %d</s:translate>
-						</s:pageBrowserRange>
-					</span>
-				</f:if>
-				<f:if condition="{resultSet.usedSearch.numberOfResults}">
-					<f:render partial="Result/PerPage" section="PerPage" arguments="{resultSet: resultSet}" />
 				</f:if>
 			</div>
 		</div>
@@ -94,7 +86,7 @@
 								<h2>{group.groupname}</h2>
 
 								<f:for each="{group.groupitems}" as="groupItem">
-									<strong>{groupItem.groupValue} <span>({groupItem.numFound})</span></strong>
+									<strong>{groupItem.groupValue} <span>({groupItem.allResultCount})</span></strong>
 									<s:widget.groupItemPaginate groupItem="{groupItem}" resultSet="{resultSet}">
 										<ol start="{pagination.resultCountStart}" class="results-list">
 											<f:for each="{documents}" as="document">

--- a/Tests/Unit/Domain/Search/ResultSet/Grouping/Parser/GroupedResultsParserTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/Grouping/Parser/GroupedResultsParserTest.php
@@ -96,6 +96,7 @@ class GroupedResultsParserTest extends UnitTest
         $this->assertSame(2, $typeGroup->getByPosition(1)->getSearchResults()->getCount(), 'There should be 2 documents in the group news');
 
         $this->assertSame(7, $searchResultsCollection->getCount(), 'There should be a 7 search results when they are fetched without groups');
+        $this->assertSame(44, $resultSet->getAllResultCount(), 'Unexpected allResultCount');
     }
 
     /**


### PR DESCRIPTION
This pr:

* Uses the method SearchResultSet::getAllResultCount instead of Search::getNumberOfResults
* Adapts the parser to calculate allResultCount
* Add's an assertion to the tests

Fixes: #13